### PR TITLE
add "dedupe" to the "keywords" section in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "yarn.lock",
     "lockfile",
     "duplicated",
-    "package manager"
+    "package manager",
+    "dedupe"
   ],
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
Thanks for the great tool. Before I knew this tool, I have edited yarn.lock by hand. It was the hell!

BTW, this PR add "dedupe" to the keywords to search for the tool in npmjs.com easily. What do you think of it?